### PR TITLE
Add two scripts -- faster submodule init and spike-commitlogger.

### DIFF
--- a/scripts/build-spike-commitlogger.sh
+++ b/scripts/build-spike-commitlogger.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+# This script will:
+#  * Build a new Spike+riscv-fesvr+riscv-pk combo at $RISCV/logger,
+#  * Rename the spike in $RISCV/logger/bin to `lspike`.
+#  * This lspike will output the commit log stream to stderr.
+
+# top-level
+git submodule update --init
+(cd rocket-chip && git submodule update --init riscv-tools)
+(cd rocket-chip/riscv-tools && git submodule update --init --recursive riscv-isa-sim riscv-fesvr riscv-pk)
+
+echo "cd rocket-chip/riscv-tools"
+cd rocket-chip/riscv-tools
+f=build-logger.sh
+
+if [[ ! -e "$f" ]]
+then
+	# If file doesn't exist, generate a new build script file.
+	echo "Generating script: rocket-chip/riscv-tools/$f"
+	echo "#! /bin/bash" >> $f
+	echo "#" >> $f
+	echo "# Script to build RISC-V ISA simulator, proxy kernel, and GNU toolchain with commit log output." >> $f
+	echo "# Tools will be installed to \$RISCV/logger." >> $f
+	echo "" >> $f
+	echo ". build.common" >> $f
+	echo "" >> $f
+	echo "echo "Starting RISC-V Toolchain build process"" >> $f
+	echo "echo "Tools will be installed to \$RISCV/logger."" >> $f
+	echo "" >> $f
+	echo "build_project riscv-fesvr --prefix=\$RISCV/logger" >> $f
+	echo "build_project riscv-isa-sim --prefix=\$RISCV/logger --with-fesvr=\$RISCV/logger --with-isa=rv64imafd --enable-commitlog" >> $f
+	echo "CC= CXX= build_project riscv-pk --prefix=\$RISCV/logger --host=riscv64-unknown-elf" >> $f
+	echo "" >> $f
+	echo "mv \$RISCV/logger/bin/spike \$RISCV/logger/bin/lspike" >> $f
+	echo "echo \"RISC-V Toolchain installation (with commit logging) completed!\"" >> $f
+else
+	echo "Using existing $f script."
+fi
+
+chmod a+x $f && echo "./$f" && ./$f
+retVal=$?
+if [ ! $retVal -eq 0 ]; then
+    echo "A error has been encountered while building the toolchain."
+fi
+exit $retVal

--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -8,7 +8,7 @@ git submodule update --init
 
 echo "cd rocket-chip/riscv-tools"
 cd rocket-chip/riscv-tools
-# We need to build a RV64G toolchain (not RVC which is the current riscv-tools default). 
+# We need to build a RV64G toolchain (not RVC which is the current riscv-tools default).
 # Therefore, let's make our own build script and then invoke it.
 f=build-rv64g.sh
 
@@ -33,7 +33,7 @@ then
 	echo "build_project riscv-openocd --prefix=\$RISCV --enable-remote-bitbang --enable-jtag_vpi --disable-werror" >> $f
 	echo "build_project riscv-tests --prefix=\$RISCV/riscv64-unknown-elf" >> $f
 	echo "" >> $f
-	echo "echo -e "\\nRISC-V Toolchain installation completed!"" >> $f
+	echo "echo \"RISC-V Toolchain installation completed!\"" >> $f
 else
 	echo "Using existing $f script."
 fi

--- a/scripts/init-submodules-no-riscv-tools.sh
+++ b/scripts/init-submodules-no-riscv-tools.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+# Script for faster checkout if you already have installed your RISC-V tools.
+
+# top-level
+git submodule update --init
+# rocket-chip (skip tools)
+(cd rocket-chip && git submodule update --init --recursive hardfloat chisel3 firrtl)
+# Skip riscv-tools.
+# torture submodules
+(cd torture && git submodule update --init --recursive)


### PR DESCRIPTION
   * Add a faster init-submodule script (don't checkout/build riscv-gcc).
   * Add a script to build and install "lspike" -- a copy of spike that
      outputs the commit log to stderr.